### PR TITLE
Re-execute Contract Interactions from History  

### DIFF
--- a/components/contract-invoker.tsx
+++ b/components/contract-invoker.tsx
@@ -35,6 +35,7 @@ import { useTheme } from "next-themes";
 import { formatResult } from "@/lib/utils";
 import { useWalletStore } from "@/store/wallet";
 import { useHistoryStore } from "@/store/history";
+import { useExplorerStore } from "@/store/explorer";
 
 const formSchema = z.object({
   contractId: z.string().min(1, "Contract ID is required"),
@@ -55,10 +56,7 @@ export function ContractInvoker() {
   const [keyValues, setKeyValues] = useState<KeyValue[]>([]);
   const { networkPassphrase } = useWalletStore();
   const { addHistory } = useHistoryStore();
-
-  useEffect(() => {
-    response
-  }, [response])
+  const { initialData, setInitialData } = useExplorerStore();
 
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
@@ -68,6 +66,23 @@ export function ContractInvoker() {
       parameters: "",
     },
   });
+
+  useEffect(() => {
+    if (initialData) {
+      form.setValue("contractId", initialData.contractId);
+      form.setValue("functionName", initialData.functionName);
+      
+      const newKeyValues = initialData.parameters.map(param => ({
+        key: param.key ,
+        value: param.value
+      }));
+      
+      setKeyValues(newKeyValues);
+      updateParametersJson(newKeyValues);
+      
+      setInitialData(null);
+    }
+  }, [initialData, form, setInitialData]);
 
   const addKeyValue = () => {
     setKeyValues([...keyValues, { key: 'String', value: "" }]);

--- a/components/history-item-modal.tsx
+++ b/components/history-item-modal.tsx
@@ -10,6 +10,7 @@ import JsonView from "@uiw/react-json-view";
 import { lightTheme } from '@uiw/react-json-view/light';
 import { vscodeTheme } from '@uiw/react-json-view/vscode';
 import { useTheme } from "next-themes";
+import { Button } from "./ui/button";
 
 interface HistoryItem {
   contractId: string
@@ -24,11 +25,12 @@ interface HistoryItem {
 interface HistoryItemModalProps {
   item: HistoryItem | null;
   onClose: () => void;
+  onExecute: (item: HistoryItem) => void;
 }
 
-export function HistoryItemModal({ item, onClose }: HistoryItemModalProps) {
+export function HistoryItemModal({ item, onClose, onExecute }: HistoryItemModalProps) {
   const { theme } = useTheme();
-
+  
   return (
     <Dialog open={!!item} onOpenChange={(open) => !open && onClose()}>
       <DialogContent className="max-w-2xl">
@@ -81,6 +83,7 @@ export function HistoryItemModal({ item, onClose }: HistoryItemModalProps) {
                 </div>
               </div>
             </div>
+            <Button onClick={() => onExecute(item)}>Execute on Explorer</Button>
           </>
         )}
       </DialogContent>

--- a/components/history.tsx
+++ b/components/history.tsx
@@ -1,5 +1,6 @@
 import { Card, CardContent } from "@/components/ui/card";
 import { useHistoryStore } from "@/store/history";
+import { useExplorerStore } from "@/store/explorer";
 import { HistoryItemModal } from "./history-item-modal";
 import { useState } from "react";
 import { WalletNetwork } from "@creit.tech/stellar-wallets-kit";
@@ -13,9 +14,24 @@ interface HistoryItem {
   status: string;
 }
 
-export function History() {
+interface HistoryProps {
+  onExecute?: () => void;
+}
+
+export function History({ onExecute }: HistoryProps) {
   const { histories } = useHistoryStore()
+  const { setInitialData } = useExplorerStore()
   const [selectedItem, setSelectedItem] = useState<HistoryItem | null>(null);
+
+  const handleExecute = (item: HistoryItem) => {
+    setInitialData({
+      contractId: item.contractId,
+      functionName: item.functionName,
+      parameters: item.parameters
+    });
+    setSelectedItem(null);
+    onExecute?.();
+  };
 
   return (
     <div className="space-y-4">
@@ -60,9 +76,11 @@ export function History() {
         </>
       )}
 
-      <HistoryItemModal item={selectedItem} onClose={() => setSelectedItem(null)} />
-
+      <HistoryItemModal 
+        item={selectedItem} 
+        onClose={() => setSelectedItem(null)} 
+        onExecute={handleExecute}
+      />
     </div>
-
   );
 }

--- a/components/main-interface.tsx
+++ b/components/main-interface.tsx
@@ -12,12 +12,13 @@ import { walletKit } from "@/lib/stellar/wallet";
 import { ISupportedWallet, WalletNetwork } from "@creit.tech/stellar-wallets-kit";
 import { useWalletStore } from "@/store/wallet";
 import { formatWallerAddresse } from "@/lib/utils";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { Label } from "@/components/ui/label";
 
 export function MainInterface() {
   const { address, network, networkPassphrase, setAddress, setNetwork, setNetworkPassphrase } = useWalletStore();
   const kit = walletKit(networkPassphrase);
+  const [activeTab, setActiveTab] = useState("explorer");
 
   async function connectWallet() {
     await kit.openModal({
@@ -97,7 +98,7 @@ export function MainInterface() {
           </div>
         </header>
 
-        <Tabs defaultValue="explorer" className="space-y-8">
+        <Tabs value={activeTab} onValueChange={setActiveTab} className="space-y-8">
           <div className="flex justify-center">
             <TabsList className="grid w-full max-w-[400px] grid-cols-2 p-1 rounded-2xl bg-muted/50 backdrop-blur-sm">
               <TabsTrigger
@@ -135,7 +136,7 @@ export function MainInterface() {
               exit={{ opacity: 0, y: -10 }}
               transition={{ duration: 0.3 }}
             >
-              <History />
+              <History onExecute={() => setActiveTab("explorer")} />
             </motion.div>
           </TabsContent>
         </Tabs>

--- a/store/explorer.ts
+++ b/store/explorer.ts
@@ -1,0 +1,19 @@
+import { create } from 'zustand'
+
+type ExplorerStore = {
+  initialData: {
+    contractId: string;
+    functionName: string;
+    parameters: any[];
+  } | null;
+  setInitialData: (data: {
+    contractId: string;
+    functionName: string;
+    parameters: any[];
+  } | null) => void;
+}
+
+export const useExplorerStore = create<ExplorerStore>()((set) => ({
+  initialData: null,
+  setInitialData: (data) => set({ initialData: data }),
+})) 


### PR DESCRIPTION
## 📌 Summary of Changes  

### 1. **New Re-execution Feature**  
- Enabled the ability to **re-execute contract interactions** directly from the history.  
- When clicking the **"Execute on Explorer"** button in the history modal, the following data is automatically loaded into the explorer:  
  - `contractId`  
  - `function`  
  - `parameters`  

### 2. **Improved User Experience**  
- Provides a faster and more efficient way to re-run previous contract calls.  
- Streamlined the process of testing and debugging repeated interactions.  

## 🔥 Impact of Changes  
✅ Enhanced usability by allowing quick re-execution from history.  
✅ Better workflow for users needing to interact with contracts repeatedly.  
